### PR TITLE
Clarify what `WORKBREW_API_TOKEN` is

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ jobs:
 > - uses: workbrew/sync-brewfiles-action@1.0.0
 > ```
 
+> [!NOTE]
+> For the `WORKBREW_API_TOKEN` please use your USER API KEY.
+
 ---
 
 ## Why this trigger?


### PR DESCRIPTION
It is not super clear what `WORKBREW_API_TOKEN` is, so this PR tries to clarify it in the `README.md` file.